### PR TITLE
Avoid crash if -[MSObject initWithDictionary:] is called with a non-dictionary argument

### DIFF
--- a/BaseModels/MSObject.m
+++ b/BaseModels/MSObject.m
@@ -35,6 +35,10 @@
     {
         return nil;
     }
+    if (![dictionary isKindOfClass:[NSDictionary class]])
+    {
+        return nil;
+    }
     self = [super init];
     if(self)
     {

--- a/GeneratedModels/MSGraphRgbColor.m
+++ b/GeneratedModels/MSGraphRgbColor.m
@@ -24,7 +24,7 @@
 
 - (Byte) r
 {
-    _r = self.dictionary[@"r"];
+    _r = [((NSNumber *)self.dictionary[@"r"]) unsignedCharValue];
     return _r;
 }
 
@@ -36,7 +36,7 @@
 
 - (Byte) g
 {
-    _g = self.dictionary[@"g"];
+    _g = [((NSNumber *)self.dictionary[@"g"]) unsignedCharValue];
     return _g;
 }
 
@@ -48,7 +48,7 @@
 
 - (Byte) b
 {
-    _b = self.dictionary[@"b"];
+    _b = [((NSNumber *)self.dictionary[@"b"]) unsignedCharValue];
     return _b;
 }
 

--- a/MSGraphClientModelsTests/BaseModels/MSObjectTests.m
+++ b/MSGraphClientModelsTests/BaseModels/MSObjectTests.m
@@ -49,6 +49,11 @@
     XCTAssertTrue([dec isEqualToString:[userItemDic description]]);
 }
 
+- (void)testInitDictionaryOtherType {
+    MSObject *msObject= [[MSObject alloc] initWithDictionary:(id)[NSNull null]];
+    XCTAssertNil(msObject);
+}
+
 - (void)testInitWithNilData {
    XCTAssertNil([[MSObject alloc] initWithData:nil error:nil]);
 }


### PR DESCRIPTION
Also fixes warnings in MSGraphRgbColor.m which was failing to unbox NSNumbers read from a dictionary.